### PR TITLE
Add git to runner image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ ARG RUNNER_VERSION="2.302.1"
 # update the base packages and add a non-sudo user
 RUN apt-get update -y && apt-get upgrade -y && useradd -m docker
 
+# add git
+RUN apt-get -y install git
+
 # install python and the packages the your code depends on along with jq so we can parse JSON
 # add additional packages as necessary
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Was testing the image and it worked fine for node builds until I started using `peaceiris/actions-gh-pages@v3` action which failed with
```bash
Error: Action failed with "Unable to locate executable file: git. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable."
```

This fixes it